### PR TITLE
AST-5073 docs(awell-orchestration): add docs for tracks queries and mutations

### DIFF
--- a/content/awell-orchestration/api-reference/mutations/start-ad-hoc-track.mdx
+++ b/content/awell-orchestration/api-reference/mutations/start-ad-hoc-track.mdx
@@ -1,0 +1,50 @@
+---
+title: Start ad hoc track
+description: Add a pre-configured ad hoc track to a patient care flow (pathway)
+---
+
+When a care flow (pathway) is active, an ad hoc track (i.e. one that has 'manually triggered' as at least one of its configured activation triggers) can be added to that care flow. This is done via the StartTrack mutation. Care flows that are not yet active, have been stopped, or have been completed cannot have ad hoc tracks added to them.
+
+## Request
+
+### Mutation
+
+```graphql
+mutation StartAdHocTrack($input: StartTrackInput!) {
+  startTrack(input: $input) {
+    success
+  }
+}
+```
+
+### Variables
+
+The `pathway_id` is the id of the patient care flow (pathway) that you want to add the ad hoc track to. The `track_id` is the id of the ad hoc track that you want to add to the patient care flow. You can find the `track_id` by using either of the [Get Ad Hoc Tracks](/awell-orchestration/api-reference/queries/get-ad-hoc-tracks) queries, using the `id` value of the desired track you wish to add as the `track_id` below.
+
+```json
+{
+  "input": {
+    "pathway_id": "{{PATHWAY_ID}}",
+    "track_id": "{{TRACK_ID}}"
+  }
+}
+```
+
+## Response
+
+```json
+{
+  "data": {
+    "startTrack": {
+      "success": true
+    }
+  }
+}
+```
+
+## Errors
+
+The following errors can be returned:
+
+- `BAD_REQUEST_ERROR`: "Care flow with id ${pathway_id} is not active. Ad hoc tracks can only be added to active care flows." -> This occurs if the patient care flow is not yet active or has been completed
+- `BAD_REQUEST_ERROR`: "Track with definition id XXXX cannot be triggered manually. Please check its configuration in Studio." -> This occurs if the ad hoc track you are trying to add to the patient care flow has not been configured to be manually triggered.

--- a/content/awell-orchestration/api-reference/mutations/stop-track.mdx
+++ b/content/awell-orchestration/api-reference/mutations/stop-track.mdx
@@ -1,0 +1,51 @@
+---
+title: Stop track
+description: Stop a track in a patient care flow (pathway)
+---
+
+Any track in a patient care flow (pathway) can be stopped. This will stop the orchestration of the track and no notifications (eg reminders) will be sent anymore. The track will come to a halt at the state it's currently in and an activity will be generated indicating that the track was stopped.
+
+## Request
+
+### Mutation
+
+```graphql
+mutation StopTrack($input: StopTrackInput!) {
+  stopTrack(input: $input) {
+    success
+  }
+}
+```
+
+### Variables
+
+The `pathway_id` is the id of the patient care flow (pathway) for which you want to stop a track. The `track_id` is the id of the track that you want to stop.
+
+```json
+{
+  "input": {
+    "pathway_id": "{{PATHWAY_ID}}",
+    "track_id": "{{TRACK_ID}}" // obtainable from the track activated activity (activity.object.id)
+  }
+}
+```
+
+## Response
+
+```json
+{
+  "data": {
+    "stopTrack": {
+      "success": true
+    }
+  }
+}
+```
+
+## Errors
+
+The following errors can be returned:
+
+- `ORCHESTRATION_ACTIVITY_ERROR`: "An error occurred when creating a `track stopped` activity" -> This occurs when there is an error generating the track stopped activity. This activity is generated after a track has been stopped so it is not critical to the functionality of the track being stopped.
+- `NOT_FOUND`: "Element XXXX not found" -> This occurs if the track to be stopped cannot be found
+- `BAD_REQUEST_ERROR`: "Element XXXXX has invalid status (XXXXX). Only active elements can be stopped." -> This occurs if the track you are trying to stop is not active (i.e. has already been stopped, discarded or completed)

--- a/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
@@ -1,0 +1,70 @@
+---
+title: Get Ad Hoc Tracks
+description: Retrieve a list of ad hoc tracks that can be added to an active patient care flow
+---
+
+When designing a care flow, specific tracks can be set to be manually added to a care flow during Orchestration on as as-needed basis. These tracks can be activated at any time via an API call using the [StartAdHocTrack mutation](/awell-orchestration/api-reference/mutations/start-ad-hoc-track). That said, you might want to retrieve these tracks to answer questions like:
+
+- Which ad hoc tracks are available to activate for this specific patient care flow?
+- Which ad hoc tracks are available to activate for published versions of this care flow?
+
+**We provide a couple of queries to get the data you need related to ad hoc tracks.** Feel free to select the one that works best for your use case.
+
+## Queries
+
+### adHocTracksByPathway
+
+Get published ad hoc track details by patient care flow (pathway) id, useful for identifying which ad hocs tracks you can start for a specific patient care flow. The `pathway_id` is the id of the patient care flow (pathway) that you want to add the ad hoc track to.
+
+```graphql
+query GetAdHocTracksByPathway($pathway_id: String!) {
+  adHocTracksByPathway(pathway_id: $pathway_id) {
+    tracks {
+      id # track_id, used in StartTrack mutation
+      title
+      release_id
+    }
+  }
+}
+```
+
+### adHocTracksByRelease
+
+Get published ad hoc track details by patient care flow (pathway) id, useful for identifying which ad hocs tracks you can start for a published version of a care flow. Each published version of a care flow has a unique release_id, which can be found in any query that returns a care flow, its activities, or any of its components (forms, messaegs, etc.).
+
+```graphql
+query GetAdHocTracksByRelease($release_id: String!) {
+  adHocTracksByRelease(release_id: $release_id) {
+    tracks {
+      id # track_id, used in StartTrack mutation
+      title
+      release_id
+    }
+  }
+}
+```
+
+## Response
+
+The response object shape is the same for both queries.
+
+```json
+{
+  "data": {
+    "adHocTracksByPathway": {
+      "tracks": [
+        {
+          "id": "123456789012345678901234",
+          "title": "Ad Hoc Track 1",
+          "release_id": "123456789012345678901234"
+        },
+        {
+          "id": "345678901234567890123456",
+          "title": "Ad Hoc Track 2",
+          "release_id": "123456789012345678901234"
+        }
+      ]
+    }
+  }
+}
+```

--- a/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
@@ -30,7 +30,7 @@ query GetAdHocTracksByPathway($pathway_id: String!) {
 
 ### adHocTracksByRelease
 
-Get published ad hoc track details by patient care flow (pathway) id, useful for identifying which ad hocs tracks you can start for a published version of a care flow. Each published version of a care flow has a unique release_id, which can be found in any query that returns a care flow, its activities, or any of its components (forms, messaegs, etc.).
+Get published ad hoc track details by release id, useful for identifying which ad hocs tracks you can start for a published version of a care flow. Each published version of a care flow (pathway) definition has a unique release_id, which can be found in any query that returns a patient care flow, its activities, or any of the care flow definition's published components (forms, messaegs, etc.).
 
 ```graphql
 query GetAdHocTracksByRelease($release_id: String!) {

--- a/content/awell-orchestration/developer-tools/changelog/1_22_2.mdx
+++ b/content/awell-orchestration/developer-tools/changelog/1_22_2.mdx
@@ -1,0 +1,22 @@
+---
+title: 1.22.2
+description: Changelog for release v1.22.2
+releaseDate: '2023-4-17'
+---
+
+## Added
+
+### New queries and mutations for Tracks
+
+We now support the ability to add special tracks designated as Ad Hoc to a patient care flow at any time, so long as the care flow is active. These tracks can be configured in the same way as any other track, and can be used to manually add additional activities to a patient's care flow when the need arises. To support this new functionality, we have added new queries and mutations to the API.
+
+The new queries are:
+
+- [GetAdHocTracks](awell-orchestration/api-reference/queries/get-ad-hoc-tracks)
+
+The new mutations are:
+
+- [StartAdHocTrack](awell-orchestration/api-reference/mutations/start-ad-hoc-track)
+- [StopTrack](awell-orchestration/api-reference/mutations/stop-track)
+
+You can learn more about them by visiting the links above.

--- a/src/components/Badge/badge.types.tsx
+++ b/src/components/Badge/badge.types.tsx
@@ -7,3 +7,4 @@ export type BadgeColorType =
   | 'purple'
   | 'red'
   | 'orange'
+  | 'yellow'

--- a/src/components/Badge/badgeStyles.tsx
+++ b/src/components/Badge/badgeStyles.tsx
@@ -22,4 +22,6 @@ export const badgeColors: { [key in BadgeColorType]: string } = {
   red: 'bg-red-100 text-red-800 dark:bg-red-200 dark:text-red-900',
   orange:
     'bg-orange-100 text-orange-800 dark:bg-orange-200 dark:text-orange-900',
+  yellow:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-200 dark:text-yellow-900',
 }

--- a/src/config/menus/awell-orchestration/apiMenu.ts
+++ b/src/config/menus/awell-orchestration/apiMenu.ts
@@ -5,6 +5,7 @@ import { type BadgeType, type MenuType } from '../../../types/menu.types'
 const badges: { [key in string]: BadgeType } = {
   patient: { label: 'Patient', color: 'green' },
   pathway: { label: 'Pathway', color: 'purple' },
+  tracks: { label: 'Tracks', color: 'yellow' },
   activity: { label: 'Activity', color: 'indigo' },
   datapoint: { label: 'Data Point', color: 'slate' },
   session: { label: 'Session', color: 'red' },
@@ -80,6 +81,11 @@ export const apiMenu: MenuType = [
         title: 'Get scheduled steps',
         path: `/${Space.AWELL_ORCHESTRATION}/api-reference/queries/get-scheduled-steps`,
         badge: badges.pathway,
+      },
+      {
+        title: 'Get ad hoc tracks',
+        path: `/${Space.AWELL_ORCHESTRATION}/api-reference/queries/get-ad-hoc-tracks`,
+        badge: badges.tracks,
       },
       {
         title: 'Get pathway activities',
@@ -196,6 +202,16 @@ export const apiMenu: MenuType = [
         title: 'Update baseline info',
         path: `/${Space.AWELL_ORCHESTRATION}/api-reference/mutations/update-baseline-info`,
         badge: badges.pathway,
+      },
+      {
+        title: 'Start ad hoc track',
+        path: `/${Space.AWELL_ORCHESTRATION}/api-reference/mutations/start-ad-hoc-track`,
+        badge: badges.tracks,
+      },
+      {
+        title: 'Stop track',
+        path: `/${Space.AWELL_ORCHESTRATION}/api-reference/mutations/stop-track`,
+        badge: badges.tracks,
       },
       {
         title: 'Start hosted activity session',


### PR DESCRIPTION
NOTE: TO BE RELEASED WITH V0.22.2 OF AWELL PLATFORM

Changes:
- docs for get ad hoc tracks query
- docs for start ad hoc track mutation
- docs for stop track mutation
- new badge for tracks and new badge colour (yellow)

![image](https://user-images.githubusercontent.com/2485818/232031399-882285ce-768f-484e-99b7-4da13fb5924e.png)

AST-5073