### PR TITLE
AST-5071 docs(awell-orchestration): rename startTrack to addTrack

### DIFF
--- a/content/awell-orchestration/api-reference/mutations/add-ad-hoc-track.mdx
+++ b/content/awell-orchestration/api-reference/mutations/add-ad-hoc-track.mdx
@@ -1,17 +1,17 @@
 ---
-title: Start ad hoc track
-description: Add a pre-configured ad hoc track to a patient care flow (pathway)
+title: Add ad hoc track
+descriptionA: Add a pre-configured ad hoc track to a patient care flow (pathway)
 ---
 
-When a care flow (pathway) is active, an ad hoc track (i.e. one that has 'manually triggered' as at least one of its configured activation triggers) can be added to that care flow. This is done via the StartTrack mutation. Care flows that are not yet active, have been stopped, or have been completed cannot have ad hoc tracks added to them.
+When a care flow (pathway) is active, an ad hoc track (i.e. one that has 'manually triggered' as at least one of its configured activation triggers) can be added to that care flow. This is done via the `addTrack` mutation. Care flows that are not yet active, have been stopped, or have been completed cannot have ad hoc tracks added to them.
 
 ## Request
 
 ### Mutation
 
 ```graphql
-mutation StartAdHocTrack($input: StartTrackInput!) {
-  startTrack(input: $input) {
+mutation AddAdHocTrack($input: AddTrackInput!) {
+  addTrack(input: $input) {
     success
   }
 }
@@ -35,7 +35,7 @@ The `pathway_id` is the id of the patient care flow (pathway) that you want to a
 ```json
 {
   "data": {
-    "startTrack": {
+    "addTrack": {
       "success": true
     }
   }

--- a/content/awell-orchestration/api-reference/mutations/add-ad-hoc-track.mdx
+++ b/content/awell-orchestration/api-reference/mutations/add-ad-hoc-track.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add ad hoc track
-descriptionA: Add a pre-configured ad hoc track to a patient care flow (pathway)
+description: Add a pre-configured ad hoc track to a patient care flow (pathway)
 ---
 
 When a care flow (pathway) is active, an ad hoc track (i.e. one that has 'manually triggered' as at least one of its configured activation triggers) can be added to that care flow. This is done via the `addTrack` mutation. Care flows that are not yet active, have been stopped, or have been completed cannot have ad hoc tracks added to them.

--- a/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-ad-hoc-tracks.mdx
@@ -3,7 +3,7 @@ title: Get Ad Hoc Tracks
 description: Retrieve a list of ad hoc tracks that can be added to an active patient care flow
 ---
 
-When designing a care flow, specific tracks can be set to be manually added to a care flow during Orchestration on as as-needed basis. These tracks can be activated at any time via an API call using the [StartAdHocTrack mutation](/awell-orchestration/api-reference/mutations/start-ad-hoc-track). That said, you might want to retrieve these tracks to answer questions like:
+When designing a care flow, specific tracks can be set to be manually added to a care flow during Orchestration on as as-needed basis. These tracks can be activated at any time via an API call using the [AddAdHocTrack mutation](/awell-orchestration/api-reference/mutations/add-ad-hoc-track). That said, you might want to retrieve these tracks to answer questions like:
 
 - Which ad hoc tracks are available to activate for this specific patient care flow?
 - Which ad hoc tracks are available to activate for published versions of this care flow?
@@ -20,7 +20,7 @@ Get published ad hoc track details by patient care flow (pathway) id, useful for
 query GetAdHocTracksByPathway($pathway_id: String!) {
   adHocTracksByPathway(pathway_id: $pathway_id) {
     tracks {
-      id # track_id, used in StartTrack mutation
+      id # track_id, used in addTrack mutation
       title
       release_id
     }
@@ -36,7 +36,7 @@ Get published ad hoc track details by release id, useful for identifying which a
 query GetAdHocTracksByRelease($release_id: String!) {
   adHocTracksByRelease(release_id: $release_id) {
     tracks {
-      id # track_id, used in StartTrack mutation
+      id # track_id, used in addTrack mutation
       title
       release_id
     }

--- a/content/awell-orchestration/developer-tools/changelog/1_22_2.mdx
+++ b/content/awell-orchestration/developer-tools/changelog/1_22_2.mdx
@@ -16,7 +16,7 @@ The new queries are:
 
 The new mutations are:
 
-- [StartAdHocTrack](awell-orchestration/api-reference/mutations/start-ad-hoc-track)
+- [StartAdHocTrack](awell-orchestration/api-reference/mutations/add-ad-hoc-track)
 - [StopTrack](awell-orchestration/api-reference/mutations/stop-track)
 
 You can learn more about them by visiting the links above.

--- a/src/config/menus/awell-orchestration/apiMenu.ts
+++ b/src/config/menus/awell-orchestration/apiMenu.ts
@@ -204,8 +204,8 @@ export const apiMenu: MenuType = [
         badge: badges.pathway,
       },
       {
-        title: 'Start ad hoc track',
-        path: `/${Space.AWELL_ORCHESTRATION}/api-reference/mutations/start-ad-hoc-track`,
+        title: 'Add ad hoc track',
+        path: `/${Space.AWELL_ORCHESTRATION}/api-reference/mutations/add-ad-hoc-track`,
         badge: badges.tracks,
       },
       {

--- a/src/types/generated/api.types.ts
+++ b/src/types/generated/api.types.ts
@@ -1174,6 +1174,8 @@ export type PublishedPathwayDefinitionsPayload = Payload & {
 export type Query = {
   __typename?: 'Query';
   activities: ActivitiesPayload;
+  adHocTracksByPathway: TracksPayload;
+  adHocTracksByRelease: TracksPayload;
   apiCall: ApiCallPayload;
   apiCalls: ApiCallsPayload;
   baselineInfo: BaselineInfoPayload;
@@ -1222,6 +1224,16 @@ export type QueryActivitiesArgs = {
   filters?: InputMaybe<FilterActivitiesParams>;
   pagination?: InputMaybe<PaginationParams>;
   sorting?: InputMaybe<SortingParams>;
+};
+
+
+export type QueryAdHocTracksByPathwayArgs = {
+  pathway_id: Scalars['String'];
+};
+
+
+export type QueryAdHocTracksByReleaseArgs = {
+  release_id: Scalars['String'];
 };
 
 
@@ -1651,8 +1663,7 @@ export type StartPathwayPayload = {
 
 export type StartTrackInput = {
   pathway_id: Scalars['String'];
-  reason?: InputMaybe<Scalars['String']>;
-  track_definition_id: Scalars['String'];
+  track_id: Scalars['String'];
 };
 
 export type StartTrackPayload = Payload & {
@@ -1888,7 +1899,15 @@ export type TextFilterEquals = {
 export type Track = {
   __typename?: 'Track';
   id: Scalars['ID'];
+  release_id?: Maybe<Scalars['String']>;
   title: Scalars['String'];
+};
+
+export type TracksPayload = Payload & {
+  __typename?: 'TracksPayload';
+  code: Scalars['String'];
+  success: Scalars['Boolean'];
+  tracks: Array<Track>;
 };
 
 export type TranslatedText = {


### PR DESCRIPTION
Changes:
- Rename startTrack mutation to addTrack
- Rename start-ad-hoc-track.mdx to add-ad-hoc-track.mdx
- Update get-ad-hoc-tracks.mdx to reflect the change

AST-5071