### PR TITLE
docs(queries): improve language for query params

### DIFF
--- a/content/awell-orchestration/api-reference/queries/get-data-point-definitions.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-data-point-definitions.mdx
@@ -54,7 +54,6 @@ query GetPathwayDataPointDefinitions(
     }
   }
 }
-
 ```
 
 ## Variables
@@ -63,29 +62,27 @@ query GetPathwayDataPointDefinitions(
 
 A `release_id` needs to be specified in order to retrieve the data dictionary for a pathway.
 
-<code className="language-json" highlightedRows={[[2]]}>
-  {`
+```json
 {
-  "release_id": "{{ RELEASE_ID }}",
-  "category": [
-    "CALCULATION",
-    "FORM",
-    "PATIENT_PROFILE",
-    "PATHWAY",
-    "TRACK",
-    "STEP"
-  ],
-  "value_type": ["BOOLEAN", "DATE", "NUMBER", "NUMBERS_ARRAY", "STRING"]
+  "release_id": "{{ RELEASE_ID }}"
 }
-  `}
-</code>
+```
 
 ### Filters
 
-All filter values are optional, if you don't provide any filter all data points for the pathway will be returned.
-Sending an empty filter will result in a search for the matching field to be empty.
+The filter is optional: if you don't provide one, all data points with the specified `release_id` will be returned.
 
-All `in` filters accept a list of values and result in an `is any of` search criteria.
+```graphql
+query GetPathwayDataPointDefinitions($release_id: String!) {
+  pathwayDataPointDefinitions(release_id: $release_id) {
+    data_point_definitions {
+      ...DataPointDefinition
+    }
+  }
+}
+```
+
+All `in` filter type accepts a list of values and results in an `is any of` search criteria.
 
 When specifying multiple filters, the resulting criteria is the conjuction of all filters.
 
@@ -105,6 +102,10 @@ When specifying multiple filters, the resulting criteria is the conjuction of al
 }
   `}
 </code>
+
+### Pagination and sorting
+
+There is no pagination or sorting available for this query. All matching patient pathways will be returned.
 
 ## How to use
 

--- a/content/awell-orchestration/api-reference/queries/get-pathways.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-pathways.mdx
@@ -59,12 +59,42 @@ query GetPathways(
 
 ## Variables
 
+### Required parameters
+
+There are no required parameters for this query. However, you should provide pagination and sorting parameters. See `Pagination and Sorting` below.
+
 ### Filters
 
-All filter values are optional, if you don't provide any filter all pathways in your organization will be returned.
-Sending an empty filter will result in a search for the matching field to be empty.
+The filter is optional: if you don't provide one, an unfiltered list of pathways will be returned.
 
-All `in` filters accept a list of values and result in an `is any of` search criteria. The `eq` filter accepts a single string and results in `is exact match` search criteria.
+```graphql
+query GetPathways(
+  $count: Float!
+  $offset: Float!
+  $sort_field: String!
+  $sort_direction: String!
+) {
+  pathways(
+    pagination: { count: $count, offset: $offset }
+    sorting: { field: $sort_field, direction: $sort_direction }
+  ) {
+    pagination {
+      count
+      offset
+      total_count
+    }
+    sorting {
+      field
+      direction
+    }
+    pathways {
+      ...Pathway
+    }
+  }
+}
+```
+
+All `in` filter type accepts a list of values and results in an `is any of` search criteria. The `eq` filter accepts a single string and results in `is exact match` search criteria.
 
 When specifying multiple filters, the resulting criteria is the conjunction of all filters.
 
@@ -80,28 +110,21 @@ When specifying multiple filters, the resulting criteria is the conjunction of a
     "offset": 0,
     "count": 20,
     "sort_field": "start_date",
-    "sort_direction": "desc"
+    "sort_direction": "DESC"
   }`}
 </code>
 
 ### Pagination and sorting
 
-Pagination and sorting are required for this query. If no pagination values are supplied, the API will return only the first 10 care flows, or 10 care flows from any specified offset. There is also an upper limit of 100 records per query. Please be aware that setting `count` greater than 100 will successfully execute but return only 100 records.
+Pagination and sorting are required for this query. If no pagination values are supplied, the API will return only the first 100 care flows, or 100 care flows from any specified offset. There is an upper limit of 100 records per query. Please be aware that setting `count` greater than 100 will successfully execute but return only 100 records.
 
 Default sorting is based on the `start_date` field, sorted from newest to oldest (i.e. descending).
 
-<code className="language-json" highlightedRows={[[8, 11]]}>
-  {`
-  {
-    "pathway_definition_id": "{{ PATHWAY_DEFINITION_ID }}",
-    "patient_id": ["{{ PATIENT_ID_1 }}", "{{ PATIENT_ID_2 }}"],
-    "start_date_earliest": '2022-01-01',
-    "start_date_latest": '2022-01-01', 
-    "release_id": ["{{ RELEASE_ID_1 }}", "{{ RELEASE_ID_2 }}"],
-    "status": ["active", "completed", "stopped"],
-    "offset": 0, // the number of records that need to be skipped
-    "count": 20,  // the number of results, also known as limit
-    "sort_field": "start_date",
-    "sort_direction": "desc"
-  }`}
-</code>
+```json
+{
+  "count": 100, // max 100
+  "offset": 0,
+  "sort_field": "start_date",
+  "sort_direction": "DESC"
+}
+```

--- a/content/awell-orchestration/api-reference/queries/get-patient-pathways.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-patient-pathways.mdx
@@ -55,29 +55,30 @@ query GetPatientPathways($patient_id: String!, $status: [String!]) {
 
 ### Filters
 
-All filter values are optional, if you don't provide any filter all pathways for the patient will be returned.
-Sending an empty filter will result in a search for the matching field to be empty.
+The filter is optional: if you don't provide one, all pathways for the patient will be returned.
 
-All `in` filters accept a list of values and result in an `is any of` search criteria.
-
-When specifying multiple filters, the resulting criteria is the conjuction of all filters.
-
-```json
-{
-  "patient_id": "{{ PATIENT_ID }}",
-  "filters": {
-    "status": {
-      "in": [""]
+```graphql
+query GetPatientPathways($patient_id: String!) {
+  patientPathways(patient_id: $patient_id) {
+    patientPathways {
+      ...Pathway
     }
   }
 }
 ```
 
-<p></p>
+The `in` filter type for status accepts a list of values and results in an `is any of` search criteria.
+
+```json
+{
+  "patient_id": "{{ PATIENT_ID }}",
+  "status": ["active", "completed"]
+}
+```
 
 #### Status
 
-You can use the following statusses in the `status` filter.
+You can use the following status values in the `status` filter array.
 
 ```graphql
 enum PathwayStatus {
@@ -88,3 +89,7 @@ enum PathwayStatus {
   stopped
 }
 ```
+
+### Pagination and sorting
+
+There is no pagination or sorting available for this query. All matching patient pathways will be returned.

--- a/content/awell-orchestration/api-reference/queries/get-patients.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-patients.mdx
@@ -67,10 +67,40 @@ query GetPatients(
 
 ## Variables
 
+### Required parameters
+
+There are no required parameters for this query. However, you should provide pagination and sorting parameters. See `Pagination and Sorting` below.
+
 ### Filters
 
-All filter values are optional, if you don't provide any filter all patients in your tenant will be returned.
-Sending an empty filter will result in a search for the matching field to be empty.
+The filter is optional: if you don't provide one, an unfiltered list of patients will be returned.
+
+```graphql
+query GetPatients(
+  $count: Float!
+  $offset: Float!
+  $sort_field: String!
+  $sort_direction: String!
+) {
+  patients(
+    pagination: { count: $count, offset: $offset }
+    sorting: { field: $sort_field, direction: $sort_direction }
+  ) {
+    pagination {
+      offset
+      count
+      total_count
+    }
+    sorting {
+      field
+      direction
+    }
+    patients {
+      ...Patient
+    }
+  }
+}
+```
 
 All `in` filters accept a list of values and result in an `is any of` search criteria. The `eq` filter accepts a single string and results in `is exact match` search criteria. The `contains` filter accepts a single string and returns any results that partially match (case-insensitively) a set of fields. For this query, the fields searched against are `name`, `patient_code` and `email`. `name` is a user's full name, if you wish to partial match on first or last name, then use the `search` filter rather than the `name` contains or equals filters.
 
@@ -88,7 +118,7 @@ When specifying multiple filters, the resulting criteria is the conjuction of al
       "offset": 0,
       "count": 20,
       "sort_field": "last_name",
-      "sort_direction": "desc"
+      "sort_direction": "DESC"
     }
   `}
 </code>
@@ -97,21 +127,16 @@ When specifying multiple filters, the resulting criteria is the conjuction of al
 
 Pagination and sorting are required for this query. If no pagination values are supplied, the API will return only the first 10 patients, or 10 patients from the specified offset. There is also an upper limit of 100 records per query. Please be aware that setting `count` greater than 100 will successfully execute but return only 100 records.
 
-Default sorting is based on the `last_name` field, sorted ascending. Only top-level patient profile fields can be used for sorting (e.g. `birth_date`, `sex`, `patient_code`).
+Default sorting is based on the `last_name` field, sorted ascending. Only top-level patient profile fields can be used for sorting (e.g. `birth_date`, `sex`, `patient_code`). Sorting by nested fields (e.g. `address.city`) is not supported.
 
-<code className="language-json" highlightedRows={[[5, 8]]}>
-  {`
-    {
-      "national_registry_number": "{{ NRNN }}",
-      "patient_code": "{{ PATIENT_CODE }}",
-      "profile_id": ["AWELL_PATIENT_ID_1", "AWELL_PATIENT_ID_2"],
-      "offset": 0, // the number of records that need to be skipped
-      "count": 20,  // the number of results, also known as limit
-      "sort_field": "last_name",
-      "sort_direction": "desc"
-    }`
-  }
-</code>
+```json
+{
+  "count": 100, // max 100
+  "offset": 0,
+  "sort_field": "last_name",
+  "sort_direction": "ASC"
+}
+```
 
 ## How to use
 

--- a/content/awell-orchestration/api-reference/queries/search-activities.mdx
+++ b/content/awell-orchestration/api-reference/queries/search-activities.mdx
@@ -68,10 +68,40 @@ query GetActivities(
 
 ## Variables
 
+### Required parameters
+
+There are no required parameters for this query. However, you should provide pagination and sorting parameters. See `Pagination and Sorting` below.
+
 ### Filters
 
-All filter values are optional, if you don't provide any filter all activities in your tenant will be returned.
-Sending an empty filter will result in a search for the matching field to be empty.
+The filter is optional: if you don't provide one, an unfiltered list of pathways will be returned.
+
+```graphql
+query GetActivities(
+  $count: Float!
+  $offset: Float!
+  $sort_field: String!
+  $sort_direction: String!
+) {
+  activities(
+    pagination: { count: $count, offset: $offset }
+    sorting: { field: $sort_field, direction: $sort_direction }
+  ) {
+    pagination {
+      count
+      offset
+      total_count
+    }
+    sorting {
+      field
+      direction
+    }
+    activities {
+      ...Activity
+    }
+  }
+}
+```
 
 All `in` filters accept a list of values and result in an `is any of` search criteria. The `eq` filter accepts a single string and results in `is exact match` search criteria.
 
@@ -95,22 +125,15 @@ When specifying multiple filters, the resulting criteria is the conjuction of al
 
 ### Pagination and sorting
 
-Pagination and sorting are required for this query. If no pagination values are supplied, the API will return only the first 10 activities, or 10 activities from the specified offset. There is also an upper limit of 100 records per query. Please be aware that setting `count` greater than 100 will successfully execute but return only 100 records.
+Pagination and sorting are required for this query. If no pagination values are supplied, the API will return only the first 100 activities, or 100 activities from the specified offset. There is an upper limit of 100 records per query. Please be aware that setting `count` greater than 100 will successfully execute but return only 100 records.
 
 Default sorting is based on the `date` field, in descending order (i.e. newest to oldest).
 
-<code className="language-json" highlightedRows={[[7, 10]]}>
-  {`
-  {
-    "action": ["ASSIGNED", "ACTIVATE"], // See ActivityAction enum
-    "activity_type": ["FORM", "MESSAGE"], // See ActivityObjectType enum
-    "activity_status": ["DONE", "ACTIVE"], // See ActivityStatus enum
-    "pathway_definition_id": ["{{ PATHWAY_DEFINITION_ID }}"],
-    "patient_id": "{{ PATIENT_ID }}",
-    "offset": 0,
-    "count": 20,
-    "sort_field": "date",
-    "sort_direction": "desc"
-  }
-  `}
-</code>
+```json
+{
+  "count": 100, // max 100
+  "offset": 0,
+  "sort_field": "start_date",
+  "sort_direction": "DESC"
+}
+```


### PR DESCRIPTION
Changes:
- update language around filters, pagination, and sorting for various queries
- fix mistake in example input params for get patient pathways query