### PR TITLE
docs: add new metadata field to form queries

### DIFF
--- a/content/awell-orchestration/api-reference/queries/get-form.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-form.mdx
@@ -3,11 +3,11 @@ title: Get form
 description: Get the form definition of a given form
 ---
 
-This query allows us to fetch the details and questions for a specific form and can be used to render the form and its questions in your UI.
+This query allows us to fetch the details and questions for a specific form and can be used to render the form and its questions in your UI..
 
 ## Evaluating display logic
 
-Forms in Awell can have questions with display / visibility logic. Meaning that you can conditionally show/hide questions based on previous answers in the form. In order to render the form to the user and show the right questions, you have 2 options:
+A form may have questions that are conditionally shown/hidden based on previous answers in the form, which can be referred to as question visibility logic. In order to ensure you're always showing the right set of questions, you have 2 options:
 
 1. Implement the logic yourself to evaluate the display logic and show/hide questions based on the answers given in a form. You can find the display logic under the `rule` field.
 2. Use the `evaluateFormRules` mutation and just send us the intermediary responses on the questions and we'll let you know what questions need to be shown/hidden. [Click here for more information on this mutation](/awell-orchestration/api-reference/mutations/evaluate-form-rules).
@@ -24,6 +24,7 @@ query GetForm($id: String!) {
       definition_id # static id from Studio
       title
       key # form key set in Studio
+      metadata # JSON metadata string set in Studio
       questions {
         id
         definition_id # static id from Studio
@@ -31,6 +32,7 @@ query GetForm($id: String!) {
         key # question key set in Studio
         dataPointValueType
         questionType
+        metadata # JSON metadata string set in Studio
         options {
           id
           value

--- a/content/awell-orchestration/api-reference/queries/get-form.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-form.mdx
@@ -3,7 +3,7 @@ title: Get form
 description: Get the form definition of a given form
 ---
 
-This query allows us to fetch the details and questions for a specific form and can be used to render the form and its questions in your UI..
+This query allows us to fetch the details and questions for a specific form and can be used to render the form and its questions in your UI.
 
 ## Evaluating display logic
 
@@ -11,6 +11,10 @@ A form may have questions that are conditionally shown/hidden based on previous 
 
 1. Implement the logic yourself to evaluate the display logic and show/hide questions based on the answers given in a form. You can find the display logic under the `rule` field.
 2. Use the `evaluateFormRules` mutation and just send us the intermediary responses on the questions and we'll let you know what questions need to be shown/hidden. [Click here for more information on this mutation](/awell-orchestration/api-reference/mutations/evaluate-form-rules).
+
+## Metadata
+
+Form and question metadata is returned in all form queries as a JSON string rather than a JSON object. This is because the metadata is defined in Studio as a JSON string and we want to avoid any potential parsing errors. You can parse the metadata string into a JSON object in your application (for example, using `JSON.parse` in JavaScript/TypeScript, `json.loads` in Python or `json_decode` in PHP or Ruby).
 
 ## Request
 

--- a/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
@@ -27,6 +27,10 @@ Please note that this query returns all forms in a published care flow or pathwa
   </figcaption>
 </figure>
 
+## Metadata
+
+Form and question metadata is returned in all form queries as a JSON string rather than a JSON object. This is because the metadata is defined in Studio as a JSON string and we want to avoid any potential parsing errors. You can parse the metadata string into a JSON object in your application (for example, using `JSON.parse` in JavaScript/TypeScript, `json.loads` in Python or `json_decode` in PHP or Ruby).
+
 ## Request
 
 ### Query

--- a/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
@@ -45,6 +45,7 @@ query GetFormsForPublishedPathway(
       definition_id # static id from Studio
       title
       key # form key set in Studio
+      metadata # JSON metadata string set in Studio
       questions {
         id
         definition_id # static id from Studio
@@ -52,6 +53,7 @@ query GetFormsForPublishedPathway(
         key # question key set in Studio
         dataPointValueType
         questionType
+        metadata # JSON metadata string set in Studio
         options {
           id
           value

--- a/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
@@ -185,6 +185,8 @@ form {
 
 For non-Form activities, this field will return `null`. Currently, the `form` field is only available on this activity query.
 
+Form and question metadata is returned in all form queries as a JSON string rather than a JSON object. This is because the metadata is defined in Studio as a JSON string and we want to avoid any potential parsing errors. You can parse the metadata string into a JSON object in your application (for example, using `JSON.parse` in JavaScript/TypeScript, `json.loads` in Python or `json_decode` in PHP or Ruby).
+
 **Example:**<br/>
 If you'd like to get all pending activities for the patient, you can filter the activities array by `activity.indirect_object.type === PATIENT`.
 

--- a/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
@@ -142,6 +142,7 @@ The table below can help you with filtering activities for the right stakeholder
 ### Including Form Content in Form Activities
 
 To simplify obtaining the content of a form for a form activity, there are two options:
+
 - as with all actions, you can use the `activity.object.id` and the related getter query (e.g. GetForm, GetMessage) to fetch the content you need
 - expand this query by including the `form` field at the `activity` root (see `...Form` in the query above), along with the form fields you are interested in. The schema of a form is identical to what you would use in the [GetForm](/awell-orchestration/api-reference/queries/get-form) query:
 
@@ -151,6 +152,7 @@ form {
   definition_id # static id from Studio
   title
   key # form key set in Studio
+  metadata # JSON metadata string set in Studio
   questions {
     id
     definition_id # static id from Studio
@@ -158,6 +160,7 @@ form {
     key # question key set in Studio
     dataPointValueType
     questionType
+    metadata # JSON metadata string set in Studio
     options {
       id
       value
@@ -180,7 +183,7 @@ form {
 }
 ```
 
-For non-Form activities, this field will return `null`. Currently, the `form` field is only available on this activity query. 
+For non-Form activities, this field will return `null`. Currently, the `form` field is only available on this activity query.
 
 **Example:**<br/>
 If you'd like to get all pending activities for the patient, you can filter the activities array by `activity.indirect_object.type === PATIENT`.

--- a/src/hooks/awell-orchestration/useForm/graphql/form.graphql.ts
+++ b/src/hooks/awell-orchestration/useForm/graphql/form.graphql.ts
@@ -6,9 +6,11 @@ export const GET_FORM = gql`
       form {
         id
         title
+        metadata
         questions {
           id
           title
+          metadata
           dataPointValueType
           options {
             id


### PR DESCRIPTION
Changes:
- add metadata field to documentation for queries where there is a form field
- improve some of the language in the GetForm query doc