### PR TITLE
Submit form documentation

### DIFF
--- a/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
+++ b/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
@@ -180,24 +180,19 @@ The following input fields are available:
   </table>
 </div>
 
----
-
 ## Errors
 
 ### Missing Value for Required Question
 
-When submitting a form response, if a required question is left unanswered, the backend will return a GraphQL error. The error response will appear as follows:
+When submitting a form response, if one or more required questions are left unanswered, the backend will return a GraphQL error. The error response will appear as follows:
 
 ```json
 {
     "errors": [
         {
-            "stack": "SubmitFormError: Required question is missing an answer\n
-            ...
-            "message": "Required question is missing an answer",
+            "message": "One or more required questions are unanswered.",
             "name": "GraphQLError",
             "originalError": {...},
-             ...
             "extensions": {
                 "errorId": "V8FiQfu8agvU7hjtakX7o",
                 "data": {
@@ -215,21 +210,20 @@ When submitting a form response, if a required question is left unanswered, the 
                             "title": "Q4"
                         }
                     ],
-                    "customMessage": "Required question is missing an answer"
+                    "customMessage": "One or more required questions are unanswered."
                 },
                 "type": "MISSING_REQUIRED_ANSWER",
                 "statusCode": 400,
                 "code": "INTERNAL_SERVER_ERROR"
-            }
+            },
+            ...
         }
     ],
     "data": null
 }
 ```
 
-**Description**: This error indicates that one or more required questions in the form were not answered.
-The `extensions` field in the error object will provide details about the missing values.
-The unanswered questions are listed under extensions.data.data, and you can check the `title`, `_key` or `definition_id` for each question to see which ones are missing answers."
+The `extensions` field in the error object will provide details about the missing values. The unanswered questions are listed under `extensions.data.data`.
 
 ## How to use
 

--- a/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
+++ b/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
@@ -180,6 +180,45 @@ The following input fields are available:
   </table>
 </div>
 
+---
+
+## Errors
+
+### Missing Value for Required Question
+
+When submitting a form response, if a required question does not have an answer, the backend will return a GraphQL error. The error response will look like this:
+
+```json
+{
+  "errors": [
+        {
+            "message": "A required field for question is missing a value.",
+            ...
+            "name": "GraphQLError",
+            ...
+            "extensions": {
+                "errorId": "TTRr2bXHM4OKMIEP-CrPm",
+                "data": {},
+                "type": "UNKNOWN_SERVER_ERROR",
+                "code": "INTERNAL_SERVER_ERROR"
+            }
+        }
+    ],
+    "data": null
+}
+
+```
+
+**Description**: This error indicates that one or more required questions in the form were not answered.
+The  `message`  field in the error object will provide details about the missing values.
+
+# How to Handle on the Frontend:
+
+Examine the GraphQL response for the `errors` field.
+If present, iterate over the `errors` array and look for the `message` key. This key will contain a list of the `question_definition_id` that are missing values.
+Use the information from the `message` key to display a user-friendly error message or handle it programmatically.
+
 ## How to use
 
 <HowToUse storyIds={['conversational-form', 'form']} />
+```

--- a/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
+++ b/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
@@ -210,9 +210,9 @@ When submitting a form response, if a required question does not have an answer,
 ```
 
 **Description**: This error indicates that one or more required questions in the form were not answered.
-The  `message`  field in the error object will provide details about the missing values.
+The `message` field in the error object will provide details about the missing values.
 
-# How to Handle on the Frontend:
+### How to Handle on the Frontend:
 
 Examine the GraphQL response for the `errors` field.
 If present, iterate over the `errors` array and look for the `message` key. This key will contain a list of the `question_definition_id` that are missing values.

--- a/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
+++ b/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
@@ -206,7 +206,6 @@ When submitting a form response, if a required question does not have an answer,
     ],
     "data": null
 }
-
 ```
 
 **Description**: This error indicates that one or more required questions in the form were not answered.
@@ -221,4 +220,3 @@ Use the information from the `message` key to display a user-friendly error mess
 ## How to use
 
 <HowToUse storyIds={['conversational-form', 'form']} />
-```

--- a/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
+++ b/content/awell-orchestration/api-reference/mutations/submit-form-response.mdx
@@ -186,20 +186,39 @@ The following input fields are available:
 
 ### Missing Value for Required Question
 
-When submitting a form response, if a required question does not have an answer, the backend will return a GraphQL error. The error response will look like this:
+When submitting a form response, if a required question is left unanswered, the backend will return a GraphQL error. The error response will appear as follows:
 
 ```json
 {
-  "errors": [
+    "errors": [
         {
-            "message": "A required field for question is missing a value.",
+            "stack": "SubmitFormError: Required question is missing an answer\n
             ...
+            "message": "Required question is missing an answer",
             "name": "GraphQLError",
-            ...
+            "originalError": {...},
+             ...
             "extensions": {
-                "errorId": "TTRr2bXHM4OKMIEP-CrPm",
-                "data": {},
-                "type": "UNKNOWN_SERVER_ERROR",
+                "errorId": "V8FiQfu8agvU7hjtakX7o",
+                "data": {
+                    "data": [
+                        {
+                            "_key": "6NGOn6QxLqra",
+                            "_id": "QuestionComponent/6NGOn6QxLqra",
+                            "definition_id": "jYQeP4fgq1_9",
+                            "title": "Q1"
+                        },
+                        {
+                            "_key": "-Nfe4khOpu4T",
+                            "_id": "QuestionComponent/-Nfe4khOpu4T",
+                            "definition_id": "VwQm8oP_u90s",
+                            "title": "Q4"
+                        }
+                    ],
+                    "customMessage": "Required question is missing an answer"
+                },
+                "type": "MISSING_REQUIRED_ANSWER",
+                "statusCode": 400,
                 "code": "INTERNAL_SERVER_ERROR"
             }
         }
@@ -209,13 +228,8 @@ When submitting a form response, if a required question does not have an answer,
 ```
 
 **Description**: This error indicates that one or more required questions in the form were not answered.
-The `message` field in the error object will provide details about the missing values.
-
-### How to Handle on the Frontend:
-
-Examine the GraphQL response for the `errors` field.
-If present, iterate over the `errors` array and look for the `message` key. This key will contain a list of the `question_definition_id` that are missing values.
-Use the information from the `message` key to display a user-friendly error message or handle it programmatically.
+The `extensions` field in the error object will provide details about the missing values.
+The unanswered questions are listed under extensions.data.data, and you can check the `title`, `_key` or `definition_id` for each question to see which ones are missing answers."
 
 ## How to use
 


### PR DESCRIPTION
Added documentation on submit-form-response for how to handle errors gracefully, if a question is required but does not have an answer.