### PR TITLE
docs(data): clarify that Awell does not store data in HL7 or FHIR format

### DIFF
--- a/content/awell-orchestration/docs/data/healthcare-interoperability.mdx
+++ b/content/awell-orchestration/docs/data/healthcare-interoperability.mdx
@@ -46,7 +46,7 @@ These standards define how healthcare information can be exchanged between diffe
 
 ### Awell & MirthConnect
 
-Our team of Mirth experts has built dozens of integrations with EMR/EHR, lab, and scheduling systems with MirthConnect. HL7, FHIR, XML, or JSON? It doesn't matter, with MirthConnect we can communicate with any system in any format.
+Today, resources in Awell are not stored in HL7 or FHIR formats. Where we do not support working with these formats directly (e.g. through mapping or transformations), we can easily convert our resources to these standardised formats using MirthConnect. Our team of Mirth experts has built dozens of integrations with EMR/EHR, lab, and scheduling systems with MirthConnect. HL7, FHIR, XML, or JSON? It doesn't matter, with MirthConnect we can communicate with any system in any format.
 
 ### Use cases
 


### PR DESCRIPTION
Changes:
- update healthcare-interoperability page (which focuses on Mirth) to clarify that we do not store data in standardised formats today