### PR TITLE
ET-469: remove commons-clinic logo from extensions page

### DIFF
--- a/pages/awell-extensions/index.tsx
+++ b/pages/awell-extensions/index.tsx
@@ -78,12 +78,6 @@ export default function Extensions() {
                 />
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  className="col-span-2 max-h-12 w-full object-contain sm:col-start-2 lg:col-span-1 bg-slate-800 rounded p-2 dark:bg-transparent dark:p-2 dark:rounded-none"
-                  src="https://commonsclinic.com/images/logos/commons-logo-light.svg"
-                  alt="Commons Clinic"
-                />
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
                   className="col-span-2 col-start-2 max-h-12 w-full object-contain sm:col-start-auto lg:col-span-1 dark:bg-white dark:p-1 dark:rounded"
                   src="https://cdn.shopify.com/s/files/1/0342/7850/6631/t/17/assets/logo.svg?v=3128126792532175881646291453"
                   alt="Better Health"

--- a/pages/awell-extensions/index.tsx
+++ b/pages/awell-extensions/index.tsx
@@ -78,6 +78,12 @@ export default function Extensions() {
                 />
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
+                  className="col-span-2 max-h-12 w-full object-contain lg:col-span-1 p-3.5 dark:bg-white dark:p-3.5 dark:rounded"
+                  src="https://www.astranahealth.com/wp-content/uploads/2024/02/Astrana_Logo_250px_space_around-1024x201.png"
+                  alt="Astrana Health"
+                />
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
                   className="col-span-2 col-start-2 max-h-12 w-full object-contain sm:col-start-auto lg:col-span-1 dark:bg-white dark:p-1 dark:rounded"
                   src="https://cdn.shopify.com/s/files/1/0342/7850/6631/t/17/assets/logo.svg?v=3128126792532175881646291453"
                   alt="Better Health"

--- a/pages/awell-extensions/index.tsx
+++ b/pages/awell-extensions/index.tsx
@@ -78,7 +78,7 @@ export default function Extensions() {
                 />
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  className="col-span-2 max-h-12 w-full object-contain lg:col-span-1 p-3.5 dark:bg-white dark:p-3.5 dark:rounded"
+                  className="col-span-2 col-start-2 max-h-12 w-full object-contain sm:col-start-auto lg:col-span-1 dark:bg-white dark:p-1 dark:rounded"
                   src="https://www.astranahealth.com/wp-content/uploads/2024/02/Astrana_Logo_250px_space_around-1024x201.png"
                   alt="Astrana Health"
                 />


### PR DESCRIPTION
### **PR Type**
enhancement
![Screenshot 2024-12-20 at 6 10 27 PM](https://github.com/user-attachments/assets/93aa1614-082e-4ba6-a650-fa638c2a379e)




___

### **Description**
- Removed the `Commons Clinic` logo from the extensions page by deleting the corresponding JSX code.
- Ensured the layout and structure of the page remain intact after the removal.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove `Commons Clinic` logo from extensions page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/awell-extensions/index.tsx

<li>Removed the <code>Commons Clinic</code> logo from the extensions page.<br> <li> Adjusted the JSX structure to reflect the removal.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/developer-hub/pull/205/files#diff-886e88a7b98f77c911367ae168e81ef1da9fe956d6aea3485376f5c04cd79a4a">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information