### PR TITLE
docs(bigquery): deprecate patient_profiles in favor of patient_data

### DIFF
--- a/content/awell-orchestration/docs/data/bigquery/data-schema.mdx
+++ b/content/awell-orchestration/docs/data/bigquery/data-schema.mdx
@@ -138,6 +138,11 @@ Table name: `patients`
 
 #### Patient profiles
 
+<Alert type="warning" title="Deprecated">
+  <p className="mb-1">The <code>patient_profiles</code> table is deprecated as of June 7, 2026. Patient profile and identifier data is now stored in the <code>patient_data</code> and <code>patient_data_latest</code> tables — see <a href="#patient-data-points">Patient data points</a> below.</p>
+  <p>The table remains available for backward compatibility, but new integrations should query <code>patient_data_latest</code> instead of <code>patient_profiles</code>.</p>
+</Alert>
+
 Table name: `patient_profiles`
 
 <PatientProfileTableSpecs />
@@ -145,6 +150,8 @@ Table name: `patient_profiles`
 #### Patient data points
 
 Table names: `patient_data` (full audited history) and `patient_data_latest` (current value per field).
+
+These tables supersede the deprecated [`patient_profiles`](#patient-profiles) table and are the recommended source for patient profile and identifier data.
 
 The `patient_data` table is the append-only audit log of patient profile and identifier values. Every change adds a new row, each carrying its **provenance** — how, when and by whom the value was set. Use `patient_data_latest` for the current value of each field, and `patient_data` when you need the full history of changes.
 


### PR DESCRIPTION
## What

Marks the BigQuery `patient_profiles` table as **deprecated** in the data-schema docs and points readers to the new `patient_data` / `patient_data_latest` tables.

As of **June 7, 2026**, patient profile and identifier data is written to the `patient_data` model (the SoR moved to `user_management`'s field-scoped, provenance-carrying store; the `patient_data` BigQuery tables were added in #227).

## Changes

- Adds an `<Alert type="warning" title="Deprecated">` notice to the **Patient profiles** section, pointing down to **Patient data points** and recommending `patient_data_latest` for new integrations.
- Adds a reciprocal "these tables supersede the deprecated `patient_profiles` table" line to the **Patient data points** intro.
- The `#### Patient profiles` heading text is intentionally **unchanged** so the existing `#patient-profiles` anchor keeps resolving.

The `patient_profiles` table description itself is left in place — it remains available for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)