### PR TITLE
docs(bigquery): add "Let AI write your queries" skill callout

### DIFF
--- a/content/awell-orchestration/docs/data/bigquery/data-schema.mdx
+++ b/content/awell-orchestration/docs/data/bigquery/data-schema.mdx
@@ -7,6 +7,13 @@ To use the data from the Awell platform, it's essential to understand some Awell
 
 Below, we explain the terminology that you'll find back in the data schema. If you have any further questions about this, please contact your Awell Customer Success Manager.
 
+<Alert type="info" title="Let AI write your queries">
+  <p className="mb-1">Don't want to write SQL by hand? Install the <a href="https://github.com/awell-health/bigquery-agent-prompt">Awell BigQuery skill</a> into your AI coding agent — Claude Code, Cursor, Codex, and <a href="https://github.com/vercel-labs/skills">many more</a> — and ask questions about your data in plain English. The skill already knows every table and column documented on this page.</p>
+  <p className="mb-1">Install it once with one command:</p>
+  <p className="mb-1"><code>npx skills add https://github.com/awell-health/bigquery-agent-prompt</code></p>
+  <p>Then just ask in plain English, for example: <em>"How many care flows were started last month?"</em> or <em>"How many forms were completed last week?"</em></p>
+</Alert>
+
 ## Terminology
 
 ### Care flow definition vs care flow


### PR DESCRIPTION
## What

Adds a friendly **info callout** near the top of the [BigQuery data-schema page](https://developers.awellhealth.com/awell-orchestration/docs/data/bigquery/data-schema) so readers can let an AI agent write their queries instead of hand-writing SQL.

## The callout

> **Let AI write your queries**
> Don't want to write SQL by hand? Install the Awell BigQuery skill into your AI coding agent (Claude Code, Cursor, Codex, and more) and ask questions in plain English — it already knows every table and column on this page.
> ```
> npx skills add https://github.com/awell-health/bigquery-agent-prompt
> ```
> Then just ask, e.g. *"How many active care flows does customer `acme` have in `awell-production`?"*

## Why

The [`bigquery-agent-prompt`](https://github.com/awell-health/bigquery-agent-prompt) repo is now packaged as an installable Agent Skill (via the [`skills`](https://github.com/vercel-labs/skills) CLI). This surfaces it right where people are reading the schema, making query-writing a one-command, plain-English experience.

Placed as an `<Alert type="info">` between the intro and Terminology — the first thing on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)