### PR TITLE
Point /faq at the new FAQ page instead of Key terms

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1296,7 +1296,7 @@
   },
   {
     "source": "/faq",
-    "destination": "https://docs.awellhealth.com/docs/get-started/key-terms",
+    "destination": "https://docs.awellhealth.com/docs/administer-and-secure/faq",
     "permanent": true
   },
   {


### PR DESCRIPTION
`/faq` currently redirects to `docs.awellhealth.com/docs/get-started/key-terms`. That was a nearest-neighbour target picked when the new docs site had no FAQ — it answers none of the questions people arrive at `/faq` with, and Thomas links to that URL in pre-sales.

All 28 questions from this repo's `content/faq.mdx` are now a page on the docs site, so the redirect points there:

```
/faq  ->  https://docs.awellhealth.com/docs/administer-and-secure/faq
```

One line changed in `redirects.json`. The other 270 entries are untouched.

⚠️ **Depends on [awell-docs#121](https://github.com/awell-health/awell-docs/pull/121)**, which creates the page. Merge this after that one, or `/faq` will redirect to a page that doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)