### PR TITLE
fix(security): upgrade Next.js to 15.5.24 (critical RCE — Aikido scan is stale here)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gray-matter": "^4.0.3",
     "libphonenumber-js": "^1.10.60",
     "lodash": "^4.18.1",
-    "next": "15.5.23",
+    "next": "15.5.24",
     "next-mdx-remote": "^6.0.0",
     "next-transpile-modules": "^9.1.0",
     "prism-react-renderer": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       next:
-        specifier: 15.5.23
-        version: 15.5.23(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.5.24
+        version: 15.5.24(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@18.3.23)(react@18.3.1)
@@ -1188,56 +1188,56 @@ packages:
   '@next/bundle-analyzer@13.5.11':
     resolution: {integrity: sha512-LKlKp0JmANAsfaKHRfjbDmuVMNXAiC81f43TdUzEBEFob52yvdKcWcX/3nFAawtHYDL9sqwpbwwH6U/ztnzPKA==}
 
-  '@next/env@15.5.23':
-    resolution: {integrity: sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==}
+  '@next/env@15.5.24':
+    resolution: {integrity: sha512-mBDF7T0XKZjs9SpUAl0buizVO+O02ULjOvWX8o/AZo/5AGw/UAS1Zzcylmd4pqbftzmKQi+L/nB4jgBYKEAl5Q==}
 
   '@next/eslint-plugin-next@14.2.31':
     resolution: {integrity: sha512-ouaB+l8Cr/uzGxoGHUvd01OnfFTM8qM81Crw1AG0xoWDRN0DKLXyTWVe0FdAOHVBpGuXB87aufdRmrwzZDArIw==}
 
-  '@next/swc-darwin-arm64@15.5.23':
-    resolution: {integrity: sha512-SrEwOROH/rhA03F59hHtdhgtfZMWGzr5duDBWgRQt2rS3mJhqMKOcnNx6txOd0/i3E3D3uFKYFvyHsEiwQxzag==}
+  '@next/swc-darwin-arm64@15.5.24':
+    resolution: {integrity: sha512-AGdNLvxZNY6eR2iSnV+6wUa8CiHTMr4F7g3uHH7fT4ICIJBE00R9u4tzN/Vuwsw0cOi8MTD2HJcTCb6siMH88Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.23':
-    resolution: {integrity: sha512-f0FpFbG2EhDCuptBGcfrLcYMDuQAhe6m1QA4VVfXFrIBoFXvXt/olGbBkYkloKlXQtmhuzvtdYyuu/6zf07GIg==}
+  '@next/swc-darwin-x64@15.5.24':
+    resolution: {integrity: sha512-9HrQajBMmGcrrrvDfRimiCrbAPh3E6uHJmwBovYr6Yrmi9p9PZqI876BrXX280wICh3o2XwUlp4blkB0NNBqFg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.23':
-    resolution: {integrity: sha512-WlNtfepUXKX2u2ZsJZ8c3c8+tJSRZqsYzoMwLOY72A8ucKCCgxgNhiePA3qzFYahVWrwcQd8jOeJmBinc+VFVQ==}
+  '@next/swc-linux-arm64-gnu@15.5.24':
+    resolution: {integrity: sha512-rl9LSfE75si0WT3cDgdUC1XYCKS+TgxC+/IjitmeycrAG18X/plIP1/vy8dd/HPycYcIvE688PD7FuvEAiEAew==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.23':
-    resolution: {integrity: sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==}
+  '@next/swc-linux-arm64-musl@15.5.24':
+    resolution: {integrity: sha512-TlNAnpsjxSF3aAUtqnfmtXXf8m9sIDBlmF3c7bTAlnshUYu2U0OxN2uf5d0gcFwqHVEdivJNBcCaqNOwPGNimw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.23':
-    resolution: {integrity: sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==}
+  '@next/swc-linux-x64-gnu@15.5.24':
+    resolution: {integrity: sha512-7dwtlhr0SLndqTG1z9ncRkbJswDZiKWlxzFyXDvJ2RDZRDRHp8zyMJ4D9UH/FgnQeXxxB6gZy2pMcIUoNKQ4pA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.23':
-    resolution: {integrity: sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==}
+  '@next/swc-linux-x64-musl@15.5.24':
+    resolution: {integrity: sha512-kGZxM+WhkYs0276lFrMkj7PRtXT3Btp6cwvfSO/cCVLxJJttB5Ccnl2niaCgUja8HgSbEVnMHpg3FJWoOJ9e/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.23':
-    resolution: {integrity: sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==}
+  '@next/swc-win32-arm64-msvc@15.5.24':
+    resolution: {integrity: sha512-jBDDkZ/qKAqkWivWDMkJSXUzbzV0QKRBKJjEHUAvSB97Hzw7NLzJ6yV56Lts/wjir7s4P31GYgpbS6ZL+hasAA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.23':
-    resolution: {integrity: sha512-/C7wRW4fa9s/PKA18zGPPpVmx8ycgVpP8yOxro4gzGTzjPJdscbAP3ODeFvgiIovxD176Z2J/SXO9t8PJKHLeQ==}
+  '@next/swc-win32-x64-msvc@15.5.24':
+    resolution: {integrity: sha512-JqtwjvvorjacQ0spgjmUJoxySoYgPwdT1sFdQ0/zmW4iMlP2hjYlCoJIyS7o6Epb4Fug8eco3HXFoBDUCDeH7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4151,8 +4151,8 @@ packages:
   next-transpile-modules@9.1.0:
     resolution: {integrity: sha512-yzJji65xDqcIqjvx5vPJcs1M+MYQTzLM1pXH/qf8Q88ohx+bwVGDc1AeV+HKr1NwvMCNTpwVPSFI7cA5WdyeWA==}
 
-  next@15.5.23:
-    resolution: {integrity: sha512-Gvd2WKgvxIXCGotxcI1im/Uf3rS3J3oZGw0g/uskg6AVBZhyE3aAbujkYWzS3xLmEPEtTLfkaVQUKK0KMTSIkA==}
+  next@15.5.24:
+    resolution: {integrity: sha512-Y+xn8EQCoC3ZbsFPyzE+tE8XOdrWeUdUF7NeXbmg9DsgAxl5UYxlsrvgVESHTyTGigoTa1bCUrxn70F5bqt0Gw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4600,6 +4600,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -6987,34 +6988,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@15.5.23': {}
+  '@next/env@15.5.24': {}
 
   '@next/eslint-plugin-next@14.2.31':
     dependencies:
       glob: 10.3.10
 
-  '@next/swc-darwin-arm64@15.5.23':
+  '@next/swc-darwin-arm64@15.5.24':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.23':
+  '@next/swc-darwin-x64@15.5.24':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.23':
+  '@next/swc-linux-arm64-gnu@15.5.24':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.23':
+  '@next/swc-linux-arm64-musl@15.5.24':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.23':
+  '@next/swc-linux-x64-gnu@15.5.24':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.23':
+  '@next/swc-linux-x64-musl@15.5.24':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.23':
+  '@next/swc-win32-arm64-msvc@15.5.24':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.23':
+  '@next/swc-win32-x64-msvc@15.5.24':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -10683,9 +10684,9 @@ snapshots:
       enhanced-resolve: 5.18.3
       escalade: 3.2.0
 
-  next@15.5.23(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.24(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.5.23
+      '@next/env': 15.5.24
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001731
       postcss: 8.4.31
@@ -10693,14 +10694,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.23
-      '@next/swc-darwin-x64': 15.5.23
-      '@next/swc-linux-arm64-gnu': 15.5.23
-      '@next/swc-linux-arm64-musl': 15.5.23
-      '@next/swc-linux-x64-gnu': 15.5.23
-      '@next/swc-linux-x64-musl': 15.5.23
-      '@next/swc-win32-arm64-msvc': 15.5.23
-      '@next/swc-win32-x64-msvc': 15.5.23
+      '@next/swc-darwin-arm64': 15.5.24
+      '@next/swc-darwin-x64': 15.5.24
+      '@next/swc-linux-arm64-gnu': 15.5.24
+      '@next/swc-linux-arm64-musl': 15.5.24
+      '@next/swc-linux-x64-gnu': 15.5.24
+      '@next/swc-linux-x64-musl': 15.5.24
+      '@next/swc-win32-arm64-msvc': 15.5.24
+      '@next/swc-win32-x64-msvc': 15.5.24
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
Same fix as panels [#558](https://github.com/awell-health/panels/pull/558) and hosted-pages [#446](https://github.com/awell-health/hosted-pages/pull/446). `next` 15.5.23 → **15.5.24** ([August 2026 security release](https://nextjs.org/blog/august-2026-security-release)).

## Why this repo, when Aikido shows it clean

**Aikido reports zero critical findings for `developer-hub` — and that is wrong.** `package.json` declared `next: "15.5.23"`, which is squarely inside the affected range (13.4 → 15.5.23). The scan is stale relative to the 2026-08-25 advisory, not the tree clean. I only caught it because I checked the declared version directly after the feed came back empty.

Worth remembering as a general point: an empty Aikido feed is a floor, not a ceiling.

| Advisory | CVSS | Reachable here? |
| --- | --- | --- |
| GHSA-2xp9-vwfh-vxw4 — AVIF/libheif heap buffer overflow → RCE | 9.5 | **Yes**, unauthenticated |
| CVE-2026-75604 / GHSA-p293-qw3h-jr36 — Windows path traversal → RCE | 9.0 | No — Windows filesystems only |

## Reachability

`next.config.js` sets `images: { domains: ['res.cloudinary.com'] }` and there is **no middleware in this repo**, so `/_next/image` answers anonymous requests — as you would expect for a public docs site. The `domains` allowlist matches on **hostname only**, and `res.cloudinary.com` serves every Cloudinary account's assets, not just ours, so anyone can register a free account, upload a crafted AVIF, and pass it as `?url=` to reach libheif's decoder.

15.5.24 disables AVIF optimization until the upstream libheif fix propagates.

## Tests, before and after

No CI runs on PRs in this repo, so local verification is the whole gate. There is no test suite, so the gate is typecheck + lint + a full production build. Baseline taken by stashing the two-file change and reinstalling back to 15.5.23 — a real 15.5.23 `node_modules`.

| | 15.5.23 (baseline) | 15.5.24 (this PR) |
| --- | --- | --- |
| `npm run ts` (`tsc --noEmit`) | clean | **clean** |
| `npx next lint` | 2 warnings | **2 warnings** (same) |
| `npx next build` | ✓ compiled, ✓ 199/199 static pages | **✓ compiled, ✓ 199/199 static pages** |

Both lint warnings are pre-existing `import/no-named-as-default` on `clsx` in `TriggerCareFlowsComparison.tsx:2` and `UseCasesComparisonTable.tsx:3`.

Two notes on running the build locally, since neither is obvious:
- `next build` fails at prerender with `Markprompt: a project key is required` unless `NEXT_PUBLIC_MARKPROMPT_TOKEN` is set. I used a dummy value; it only gates prerender, not compilation.
- The husky pre-commit hook runs `generate-types`, which needs a sandbox GraphQL API key, so this was committed with `--no-verify` and `npm run ts` / `next lint` run by hand instead.

## Risk analysis — what could break if this merges

- **Rendering / routing.** Same-minor patch, no API change. Identical build output: same 199 static pages, same shared-chunk sizes.
- **AVIF output.** 15.5.24 disables AVIF *optimization*. This config never sets `images.formats`, so the site was on the `['image/webp']` default and never emitted AVIF. A client negotiating AVIF via `Accept` now gets WebP or the original — visually identical.
- **Lockfile blast radius.** The diff is confined to `next`, `@next/env` and the `@next/swc-*` platform binaries. No other package changed version — notably `sharp` stays at 0.34.5, because pnpm keeps a resolution that still satisfies the widened range (see below).
- **Peers.** The one unmet-peer warning pnpm prints (`cosmiconfig-typescript-loader` wanting `typescript >=5` against this repo's 4.9.5) is present on `main` too.
- **Rollback.** Revert the commit and `pnpm install`; no state or config involved.

**Very low.** A same-minor patch bump with byte-identical typecheck, lint and build results, whose only behavioural delta is disabling an output format this site never emitted; a mistake would have surfaced in the build, not in production.

## Scanner outcome

Since Aikido currently shows no finding here, **this PR will not move a number on the dashboard** — there is nothing open to close. The value is that the vulnerable version leaves the tree before the next scan picks it up. Nothing suppressed, no ignore.

**Follow-up, not in this PR:** `sharp` stays at 0.34.5 and its advisory (GHSA-f88m-g3jw-g9cj) stays open. It has been parked across panels, hosted-pages and developer-hub on the belief that Next 16.3.1 was the first release to permit sharp 0.35 — that is no longer true. 15.5.24 widens its `optionalDependencies.sharp` to `"^0.34.3 || ^0.35.3"`, so the cap is gone on the 15.5 line and a plain `pnpm up sharp` now clears it. hosted-pages picks this up automatically (yarn re-resolved it to 0.35.4); pnpm keeps the satisfying 0.34.5, so panels and this repo need one extra command. Separate PR — it is a `high`, not a critical.