### PR TITLE
Stop redirecting the two playgrounds — they are apps, not pages

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1145,11 +1145,6 @@
     "permanent": true
   },
   {
-    "source": "/awell-orchestration/playground",
-    "destination": "https://docs.awellhealth.com/api-reference/tools/api-tools",
-    "permanent": true
-  },
-  {
     "source": "/awell-score",
     "destination": "https://docs.awellhealth.com/api-reference",
     "permanent": true
@@ -1192,11 +1187,6 @@
   {
     "source": "/awell-score/docs/getting-started/endpoints",
     "destination": "https://docs.awellhealth.com/api-reference/score/awell-score-api",
-    "permanent": true
-  },
-  {
-    "source": "/awell-score/docs/getting-started/playground",
-    "destination": "https://docs.awellhealth.com/api-reference/tools/api-tools",
     "permanent": true
   },
   {


### PR DESCRIPTION
Mike reported that the Orchestration playground link "didn't port cleanly." It didn't port because it isn't a page — and the redirect list treated it as one.

## What happened

`/awell-orchestration/playground` is a self-contained **GraphiQL** instance (`pages/awell-orchestration/playground.tsx`, 50 lines) wired to the sandbox API. `/awell-score/docs/getting-started/playground` is an interactive Score API request builder. **Both still exist in this repo and still work.** The redirect was the only thing stopping them — and it sent people to `docs.awellhealth.com/api-reference/tools/api-tools`, a prose page that describes the playground and, because of this redirect, could not link to it.

`migration/link-map-notes.md` §3 in awell-docs flagged this in July — *"interactive tools are apps, not pages, so 'port' doesn't apply; rebuild or stay hosted?"* — and left it open. The redirect generator resolved it by default, in the wrong direction.

## The fix

Remove 2 of 271 entries:

```
/awell-orchestration/playground
/awell-score/docs/getting-started/playground
```

This costs nothing: the deployment has to stay alive indefinitely anyway to serve the other 269 redirects, so hosting two tool pages on it is free. Rebuilding them in Fumadocs is a separate, optional project.

## Left in place, deliberately

| Redirect | Why it stays |
|---|---|
| `/awell-orchestration/developer-tools/api/playground` | Prose page *about* the playground. Docs now carries that content and links the tool |
| `/awell-orchestration/developer-tools/playground` | Legacy alias of the same |
| `/awell-score/docs/getting-started/score-explorer` | Prose page; the tool it described is the standalone app at `score.staging.awellhealth.com`, which docs now links |
| `/awell-orchestration/developer-tools/example-projects/orchestration-stories` | Renders `<StoryBrowser />` — a **third** in-site app. What it fetches is unverified, so un-redirecting could expose a broken page. Docs links the `awell-samples/orchestration-stories` repo instead. Worth un-redirecting separately once someone confirms it loads |

## Verify after merge

```
curl -sSI https://developers.awellhealth.com/awell-orchestration/playground | head -1
```
Expect `200`, not `308`. Then open it in a browser and confirm the schema loads — that depends on `NEXT_PUBLIC_SANDBOX_GRAPHQL_API_URL` in the Vercel project (present in `.env.example`; it was live before the redirect).

**Merge this before the companion awell-docs PR**, which links to these URLs. Linking first is harmless but pointless — the link would bounce straight back to the page it's on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)